### PR TITLE
create and use an external settings file

### DIFF
--- a/sqm-autorate.config
+++ b/sqm-autorate.config
@@ -1,0 +1,13 @@
+config network
+        option transmit_interface 'eth0'
+        option receive_interface 'ifb4eth0'
+        option transmit_kbits_base '25750'
+        option receive_kbits_base '462500'
+        option transmit_kbits_min '500'
+        option receive_kbits_min '1500'
+
+config output
+        option verbose 'true'
+        option stats_file '/root/sqm-autorate.csv'
+        option speed_hist_file '/root/sqm-autorate.csv'
+        option hist_size '100'


### PR DESCRIPTION
I see this as as an example rather than something that can be committed as is
Issues
1. Naming of the settings in the external config file. These should be thought through in terms of what users can easily understand
2. Error handling and defaults for if there is a missing settings file
3. Add readme instructions to move `sqm-autorate.config` to `/etc/config/sqm-autorate`