### PR TITLE
more advanced settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ Generally, configuration should be performed via the `/etc/config/sqm-autorate` 
 | output | stats_file | The location to which the autorate OWD reflector stats will be written. | '/tmp/sqm-autorate.csv' |
 | output | speed_hist_file | The location to which autorate speed adjustment history will be written. | '/tmp/sqm-speedhist.csv' |
 | advanced_settings | speed_hist_size | The amount of "safe" speed history which the algorithm will maintain for reference during times of increased latency/congestion. Set too high, the algorithm will take days or weeks to stabilise. Set too low, the algorithm may not have enough good values to stabilise on.  | '100' |
-| advanced_settings | rtt_delta_bufferbloat | The amount of increase in RTT that indicates bufferbloat. For high speed and relatively stable fiber connections, this can be reduced. For LTE and DOCIS/cable connections, the default should be correct. | 15 |
+| advanced_settings | rtt_delta_bufferbloat | The amount of increase in RTT that indicates bufferbloat. For high speed and relatively stable fiber connections, this can be reduced. For LTE and DOCIS/cable connections, the default should be correct. | '15' |
+| advanced_settings | high_load_level | The load factor used to signal high network load. Between 0.67 and 0.95. | '0.8' |
+| advanced_settings | linear_increment_kbits | How much KBits to increment the CAKE limit when the algorithim is in linear mode.  | '500' |
 | advanced_settings | reflector_type | This is intended for future use and details are TBD. | 'icmp' |
 
 Advanced users may override values (following comments) directly in `/usr/lib/sqm-autorate/sqm-autorate.lua` as comfort level dictates.


### PR DESCRIPTION
- `high_load_level` - to allow some variation from the default 0.8
- `linear_increment_kbits` to allow increments of, for example, 100KBits