### PR TITLE
Develop/softstart

### DIFF
--- a/lib/sqm-autorate.lua
+++ b/lib/sqm-autorate.lua
@@ -1090,9 +1090,11 @@ local function conductor()
     -- Set a packet ID
     local packet_id = cur_process_id + 32768
 
-    -- Set initial TC values
-    update_cake_bandwidth(dl_if, base_dl_rate)
-    update_cake_bandwidth(ul_if, base_ul_rate)
+    -- Set initial TC values to minimum
+    -- so there should be no initial bufferbloat to
+    -- fool the baseliner
+    update_cake_bandwidth(dl_if, min_dl_rate)
+    update_cake_bandwidth(ul_if, min_ul_rate)
 
     local threads = {
         receiver = lanes.gen("*", {
@@ -1101,9 +1103,6 @@ local function conductor()
         baseliner = lanes.gen("*", {
             required = {"posix", "posix.time"}
         }, baseline_calculator)(),
-        regulator = lanes.gen("*", {
-            required = {"posix", "posix.time"}
-        }, ratecontrol)(),
         pinger = lanes.gen("*", {
             required = {bit_mod, "posix.sys.socket", "posix.time", "vstruct"}
         }, ts_ping_sender)(reflector_type, packet_id, tick_duration),
@@ -1113,7 +1112,15 @@ local function conductor()
     }
     local join_timeout = 0.5
 
-    -- Start this whole thing in motion!
+    nsleep(10,0) -- sleep 10 seconds before we start adjusting speeds
+    update_cake_bandwidth(dl_if,base_dl_rate*0.6)
+    update_cake_bandwidth(ul_if,base_ul_rate*0.6)
+    
+    threads["regulator"] = lanes.gen("*", {
+            required = {"posix", "posix.time"}
+        }, ratecontrol)()
+
+        -- Start this whole thing in motion!
     while true do
         for name, thread in pairs(threads) do
             local _, err = thread:join(join_timeout)

--- a/lib/sqm-autorate.lua
+++ b/lib/sqm-autorate.lua
@@ -612,8 +612,11 @@ local function ratecontrol()
     local lastchg_t = lastchg_s - start_s + lastchg_ns / 1e9
     local lastdump_t = lastchg_t - 310
 
-    local cur_dl_rate = base_dl_rate
-    local cur_ul_rate = base_ul_rate
+    local cur_dl_rate = base_dl_rate * 0.6
+    local cur_ul_rate = base_ul_rate * 0.6
+    update_cake_bandwidth(dl_if, cur_dl_rate)
+    update_cake_bandwidth(ul_if, cur_ul_rate)
+
     local rx_bytes_file = io.open(rx_bytes_path)
     local tx_bytes_file = io.open(tx_bytes_path)
 
@@ -1115,8 +1118,6 @@ local function conductor()
     local join_timeout = 0.5
 
     nsleep(10,0) -- sleep 10 seconds before we start adjusting speeds
-    update_cake_bandwidth(dl_if,base_dl_rate*0.6)
-    update_cake_bandwidth(ul_if,base_ul_rate*0.6)
 
     threads["regulator"] = lanes.gen("*", {
             required = {"posix", "posix.time"}

--- a/lib/sqm-autorate.lua
+++ b/lib/sqm-autorate.lua
@@ -347,6 +347,7 @@ end
 
 local function update_cake_bandwidth(iface, rate_in_kbit)
     local is_changed = false
+    rate_in_kbit = math.floor(rate_in_kbit)
     if (iface == dl_if and rate_in_kbit >= min_dl_rate) or (iface == ul_if and rate_in_kbit >= min_ul_rate) then
         os.execute(string.format("tc qdisc change root dev %s cake bandwidth %sKbit", iface, rate_in_kbit))
         is_changed = true

--- a/lib/sqm-autorate.lua
+++ b/lib/sqm-autorate.lua
@@ -1095,7 +1095,8 @@ local function conductor()
     -- fool the baseliner
     update_cake_bandwidth(dl_if, min_dl_rate)
     update_cake_bandwidth(ul_if, min_ul_rate)
-
+    nsleep(0,5e8)
+    
     local threads = {
         receiver = lanes.gen("*", {
             required = {bit_mod, "posix.sys.socket", "posix.time", "vstruct"}
@@ -1115,7 +1116,7 @@ local function conductor()
     nsleep(10,0) -- sleep 10 seconds before we start adjusting speeds
     update_cake_bandwidth(dl_if,base_dl_rate*0.6)
     update_cake_bandwidth(ul_if,base_ul_rate*0.6)
-    
+
     threads["regulator"] = lanes.gen("*", {
             required = {"posix", "posix.time"}
         }, ratecontrol)()

--- a/lib/sqm-autorate.lua
+++ b/lib/sqm-autorate.lua
@@ -349,7 +349,7 @@ local function update_cake_bandwidth(iface, rate_in_kbit)
     local is_changed = false
     rate_in_kbit = math.floor(rate_in_kbit)
     if (iface == dl_if and rate_in_kbit >= min_dl_rate) or (iface == ul_if and rate_in_kbit >= min_ul_rate) then
-        os.execute(string.format("tc qdisc change root dev %s cake bandwidth %sKbit", iface, rate_in_kbit))
+        os.execute(string.format("tc qdisc change root dev %s cake bandwidth %dKbit", iface, rate_in_kbit))
         is_changed = true
     end
     return is_changed


### PR DESCRIPTION
This is a quick change that ensures when we start up we aren't fooled by ongoing transfers with a lot of bufferbloat. First, we set the speeds to the minimum and sleep for 500ms, then we start up all the threads except the rate control thread... then we wait 10 seconds for the choice of reflectors and baselining to get set up right, and boost the speed to a middle-range value and start up the rate control thread. This should prevent us from having problems if we start up during on-going heavy traffic.